### PR TITLE
Handle alerts on inbrowser exit event

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -764,16 +764,16 @@
     [CDVUserAgentUtil releaseLock:&_userAgentLockToken];
     self.currentURL = nil;
 
-    if ((self.navigationDelegate != nil) && [self.navigationDelegate respondsToSelector:@selector(browserExit)]) {
-        [self.navigationDelegate browserExit];
-    }
-
-    __weak UIViewController* weakSelf = self;
+    __weak CDVInAppBrowserViewController* weakSelf = self;
 
     // Run later to avoid the "took a long time" log message.
     dispatch_async(dispatch_get_main_queue(), ^{
         if ([weakSelf respondsToSelector:@selector(presentingViewController)]) {
-            [[weakSelf presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+            [[weakSelf presentingViewController] dismissViewControllerAnimated:YES completion:^{
+                if ((weakSelf.navigationDelegate != nil) && [weakSelf.navigationDelegate respondsToSelector:@selector(browserExit)]) {
+                    [weakSelf.navigationDelegate browserExit];
+                }
+            }];
         } else {
             [[weakSelf parentViewController] dismissViewControllerAnimated:YES completion:nil];
         }


### PR DESCRIPTION
[CB-10855] - cordova-plugin-dialogs doesn't work on cordova-plugin-inappbrowser exit event

https://stackoverflow.com/questions/34125156/alert-not-displayed-from-cordova-inappbrowser-event-listener-conflict-w-cor/35982716#35982716